### PR TITLE
Add scenario outlines and refactor a bit to clean things up.

### DIFF
--- a/lib/cabbage/feature/helpers.ex
+++ b/lib/cabbage/feature/helpers.ex
@@ -1,0 +1,30 @@
+defmodule Cabbage.Feature.Helpers do
+  @moduledoc false
+  def add_step(module, regex, vars, state, block, metadata) do
+    steps = Module.get_attribute(module, :steps) || []
+    Module.put_attribute(module, :steps, [{:{}, [], [regex, vars, state, block, metadata]} | steps])
+    quote(do: nil)
+  end
+
+  def file(file) do
+    String.replace_leading file, "#{File.cwd!}/", ""
+  end
+
+  def metadata(env, function) do
+     %{file: file(env.file), line: env.line, module: env.module, function: function, arity: 4}
+  end
+
+  def stacktrace(module, metadata) do
+    [{module, metadata[:function], metadata[:arity], [file: metadata[:file], line: metadata[:line]]}]
+  end
+
+  def agent_name(scenario_name) do
+    :"cabbage_integration_test-#{scenario_name}"
+  end
+
+  @keys ~w(async case describe file integration line test type)a
+  def remove_hidden_state(state) do
+    Map.drop(state, @keys)
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Cabbage.Mixfile do
     [
       app: :cabbage,
       version: @version,
-      elixir: "~> 1.2",
+      elixir: "~> 1.3",
       source_url: "git@github.com:cabbage-ex/cabbage.git",
       homepage_url: "https://github.com/cabbage-ex/cabbage",
       elixirc_paths: elixirc_paths(Mix.env),

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Cabbage.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:gherkin, "~> 1.0"},
+      {:gherkin, "~> 1.2"},
       {:ex_doc, "~> 0.10", only: :dev},
       {:earmark, "~> 0.1", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
-  "gherkin": {:hex, :gherkin, "1.0.0", "b32e44d67bd8b55149caff8c369517b2ab84fbd3822556f7f963277e82d316f3", [:mix], []}}
+  "gherkin": {:hex, :gherkin, "1.2.0", "39a27ba00aed4cee4165a7d4003b43db671e551854e82c2f8dd07a37a4154aad", [:mix], []}}

--- a/test/features/coffee_outline.feature
+++ b/test/features/coffee_outline.feature
@@ -1,0 +1,16 @@
+Feature: Serve coffee
+  Coffee should not be served until paid for
+  Coffee should not be served until the button has been pressed
+  If there is no coffee left then money should be refunded
+
+  Scenario Outline: Buy coffee
+    Given there are <coffees> coffees left in the machine
+    And I have deposited $<money>
+    When I press the coffee button
+    Then I should be served <served> coffees
+
+  Examples:
+    | coffees | money | served |
+    |  12     |  6    |  12    |
+    |  2      |  3    |  2     |
+    |  0      |  10   |  0     |

--- a/test/outline_test.exs
+++ b/test/outline_test.exs
@@ -1,0 +1,19 @@
+defmodule Cabbage.OutlineTest do
+  use Cabbage.Feature, file: "coffee_outline.feature"
+
+  import_feature Cabbage.GlobalFeatures
+
+  setup do
+    {:ok, %{starting: :state}}
+  end
+
+  defwhen ~r/^I press the coffee button$/, _, %{deposited: deposited} do
+    {:ok, %{deposited: deposited - 1}}
+  end
+
+  defthen ~r/^I should be served (?<served>\d+) coffees$/, %{served: served}, %{coffees: coffees} do
+    served = String.to_integer(served)
+    assert coffees - served >= 0
+    {:ok, %{coffees: coffees - served}}
+  end
+end


### PR DESCRIPTION
@meadsteve Got scenario outlines working a bit now (dependent upon https://github.com/cabbage-ex/gherkin/pull/2) and I've cleaned up error messages when match errors occur since it doesn't seem to be reporting the proper line number correctly (always points at the use `Cabbage.Feature` line for some reason).