### PR TITLE
when processing state updates, the new state would not update the old state

### DIFF
--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -186,11 +186,11 @@ defmodule Cabbage.Feature do
     quote generated: true do
       with {_type, unquote(vars)} <- {:variables, unquote(Macro.escape(named_vars))},
            {_type, state = unquote(state_pattern)} <- {:state, Agent.get(unquote(agent_name(scenario_name)), &(&1))}
-           do
+      do
         new_state = case unquote(block) do
-                     {:ok, new_state} -> Map.merge(new_state, state)
-                     _ -> state
-                   end
+                      {:ok, new_state} -> Map.merge(state, new_state)
+                      _ -> state
+                    end
         Agent.update(unquote(agent_name(scenario_name)), fn(_) -> new_state end)
         Logger.info ["\t\t", IO.ANSI.cyan, unquote(step_type), " ", IO.ANSI.green, unquote(step.text)]
       else

--- a/test/changing_names_test.exs
+++ b/test/changing_names_test.exs
@@ -1,0 +1,18 @@
+defmodule Cabbage.ChangingNamesTest do
+  use Cabbage.Feature, file: "changing_names.feature"
+
+  defgiven ~r/^I am a User$/, _vars, _state do
+    nil
+  end
+
+  defand ~r/^I set my name to "(?<name>[^"]+)"$/, %{name: name}, _state do
+    {:ok, %{username: name}}
+  end
+
+  defthen ~r/^my name is "(?<name>[^"]+)"$/, %{name: name}, %{username: username} do
+    assert username == name
+  end
+
+
+
+end

--- a/test/features/changing_names.feature
+++ b/test/features/changing_names.feature
@@ -1,0 +1,8 @@
+Feature: Users have names
+  Users names can be changed
+
+  Scenario: Users can change their name
+    Given I am a User
+    And I set my name to "Jayne"
+    When I set my name to "Mal"
+    Then my name is "Mal"


### PR DESCRIPTION
Because of the way `Map.merge/2` works, the new state would not update the old state.

[Map.merge/2](https://hexdocs.pm/elixir/Map.html#merge/2)

Also added a test covering this logic.

