### PR TITLE
Swap merge order in setup

### DIFF
--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -180,7 +180,7 @@ defmodule Cabbage.Feature do
                   Logger.warn "Cabbage: Ignoring tag @#{tag}!"
               end
             end
-            {:ok, Map.merge(context || %{}, Cabbage.Feature.Helpers.fetch_state(unquote(scenario.name), __MODULE__))}
+            {:ok, Map.merge(Cabbage.Feature.Helpers.fetch_state(unquote(scenario.name), __MODULE__), context || %{})}
           end
 
           ExUnit.Case.register_test(unquote(Macro.escape(%{env | line: scenario.line})), :test, unquote(scenario.name), [])

--- a/test/changing_state_test.exs
+++ b/test/changing_state_test.exs
@@ -1,0 +1,25 @@
+defmodule Cabbage.ChangingStateTest do
+  use Cabbage.Feature, async: true, file: "changing_state.feature"
+
+  setup context do
+    {:ok, params: %{start: :state}}
+  end
+
+  defgiven ~r/^a start state$/, _vars, state do
+    {:ok, state}
+  end
+
+  defthen ~r/^the state is not changed$/, _vars, state do
+    assert state.params == %{start: :state}
+    {:ok, state}
+  end
+
+  defwhen ~r/^I change the state$/, _vars, state do
+    {:ok, %{params: %{new: :state}}}
+  end
+
+  defthen ~r/^the state is changed$/, _vars, state do
+    assert state.params == %{new: :state}
+    {:ok, state}
+  end
+end

--- a/test/features/changing_state.feature
+++ b/test/features/changing_state.feature
@@ -1,0 +1,11 @@
+Feature: Changing state
+  Users can change state
+
+  Scenario: No state change
+    Given a start state
+    Then the state is not changed
+
+  Scenario: State change
+    Given a start state
+    When I change the state
+    Then the state is changed


### PR DESCRIPTION
This pull request fixes #32. I was having the same issue and it seems the context was merged in the wrong order. Please review and let me know what you think.