### PR TITLE
Fix module attribute registration and support elixir 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.3.4-dev
+
+- Support for Elixir 1.7 #50.
+
 ### v0.3.3
 - Support for Elixir 1.5 #38. Thanks to @lboekhorst and @rawkode
 

--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -127,7 +127,7 @@ defmodule Cabbage.Feature do
     is_feature = !match?(nil, opts[:file])
 
     Module.register_attribute(__CALLER__.module, :steps, accumulate: true)
-    Module.register_attribute(__CALLER__.module, :tags, [])
+    Module.register_attribute(__CALLER__.module, :tags, accumulate: true)
 
     quote do
       unquote(if is_feature do

--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -125,6 +125,10 @@ defmodule Cabbage.Feature do
   defmacro __using__(opts) do
     {opts, exunit_opts} = Keyword.split(opts, @feature_opts)
     is_feature = !match?(nil, opts[:file])
+
+    Module.register_attribute(__CALLER__.module, :steps, accumulate: true)
+    Module.register_attribute(__CALLER__.module, :tags, [])
+
     quote do
       unquote(if is_feature do
         quote do
@@ -135,9 +139,6 @@ defmodule Cabbage.Feature do
       @before_compile {unquote(__MODULE__), :expose_metadata}
       import unquote(__MODULE__)
       require Logger
-
-      Module.register_attribute(__MODULE__, :steps, accumulate: true)
-      Module.register_attribute(__MODULE__, :tags, [])
 
       unquote(if is_feature do
         quote do

--- a/lib/cabbage/feature/helpers.ex
+++ b/lib/cabbage/feature/helpers.ex
@@ -3,8 +3,7 @@ defmodule Cabbage.Feature.Helpers do
   require Logger
 
   def add_step(module, regex, vars, state, block, metadata) do
-    steps = Module.get_attribute(module, :steps) || []
-    Module.put_attribute(module, :steps, [{:{}, [], [regex, vars, state, block, metadata]} | steps])
+    Module.put_attribute(module, :steps, {:{}, [], [regex, vars, state, block, metadata]})
     quote(do: nil)
   end
 

--- a/lib/cabbage/feature/helpers.ex
+++ b/lib/cabbage/feature/helpers.ex
@@ -9,8 +9,7 @@ defmodule Cabbage.Feature.Helpers do
 
   def add_tag(module, "@" <> tag_name, block), do: add_tag(module, tag_name, block)
   def add_tag(module, tag_name, block) do
-    tags = Module.get_attribute(module, :tags) || []
-    Module.put_attribute(module, :tags, [{tag_name, block} | tags])
+    Module.put_attribute(module, :tags, {tag_name, block})
     quote(do: nil)
   end
 

--- a/test/changing_state_test.exs
+++ b/test/changing_state_test.exs
@@ -14,7 +14,7 @@ defmodule Cabbage.ChangingStateTest do
     {:ok, state}
   end
 
-  defwhen ~r/^I change the state$/, _vars, state do
+  defwhen ~r/^I change the state$/, _vars, _state do
     {:ok, %{params: %{new: :state}}}
   end
 


### PR DESCRIPTION
With Elixir 1.7, we get the following error when running the tests:

```
Compiling 4 files (.ex)

== Compilation error in file test/changing_names_test.exs ==
** (MissingStepError) Please add a matching step for:
"Given I am a User"

  defgiven ~r/^I am a User$/, _vars, state do
    # Your implementation here
  end

    (cabbage) lib/cabbage/feature.ex:235: Cabbage.Feature.compile/4
    (elixir) lib/enum.ex:1314: Enum."-map/2-lists^map/1-0-"/2
    (cabbage) lib/cabbage/feature.ex:192: anonymous fn/4 in Cabbage.Feature."MACRO-__before_compile__"/2
    (elixir) lib/enum.ex:1314: Enum."-map/2-lists^map/1-0-"/2
    (cabbage) expanding macro: Cabbage.Feature.__before_compile__/1
    test/changing_names_test.exs:1: Cabbage.ChangingNamesTest (module)
    (elixir) lib/code.ex:767: Code.require_file/2
    (elixir) lib/kernel/parallel_compiler.ex:209: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/6
```

erlang 21.0.4
elixir 1.7.1

The problem is due to changes to the way the module attributes are stored in ETS and the fact that the registration is not done __upfront__ when calling `use Cabbage.Feature`.

Todo:

- [x] Fix code
- [x] Test with a dummy application
