### PR TITLE
Dynamic global tag

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  line_length: 120
+]

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,6 +4,7 @@ use Mix.Config
 
 config :logger, level: :info
 
+config :cabbage, global_tags: :global_integration_test
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment
 # by uncommenting the line below and defining dev.exs, test.exs and such.

--- a/lib/cabbage.ex
+++ b/lib/cabbage.ex
@@ -2,4 +2,5 @@ defmodule Cabbage do
   @moduledoc """
   """
   def base_path(), do: Application.get_env(:cabbage, :features, "test/features/")
+  def global_tags(), do: Application.get_env(:cabbage, :global_tags, []) |> List.wrap()
 end

--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -130,32 +130,41 @@ defmodule Cabbage.Feature do
     Module.register_attribute(__CALLER__.module, :tags, accumulate: true)
 
     quote do
-      unquote(if is_feature do
-        quote do
-          @before_compile unquote(__MODULE__)
-          use unquote(opts[:template] || ExUnit.Case), unquote(exunit_opts)
+      unquote(
+        if is_feature do
+          quote do
+            @before_compile unquote(__MODULE__)
+            use unquote(opts[:template] || ExUnit.Case), unquote(exunit_opts)
+          end
         end
-      end)
+      )
+
       @before_compile {unquote(__MODULE__), :expose_metadata}
       import unquote(__MODULE__)
       require Logger
 
-      unquote(if is_feature do
-        quote do
-          @feature File.read!("#{Cabbage.base_path}#{unquote(opts[:file])}") |> Gherkin.parse() |> Gherkin.flatten()
-          @scenarios @feature.scenarios
+      unquote(
+        if is_feature do
+          quote do
+            @feature File.read!("#{Cabbage.base_path()}#{unquote(opts[:file])}")
+                     |> Gherkin.parse()
+                     |> Gherkin.flatten()
+            @scenarios @feature.scenarios
+          end
         end
-      end)
+      )
     end
   end
 
   defmacro expose_metadata(env) do
     steps = Module.get_attribute(env.module, :steps) || []
     tags = Module.get_attribute(env.module, :tags) || []
+
     quote generated: true do
       def raw_steps() do
         unquote(Macro.escape(steps))
       end
+
       def raw_tags() do
         unquote(Macro.escape(tags))
       end
@@ -167,29 +176,64 @@ defmodule Cabbage.Feature do
     steps = Module.get_attribute(env.module, :steps) || []
     tags = Module.get_attribute(env.module, :tags) || []
 
-    Enum.with_index(scenarios) |> Enum.map(fn {scenario, test_number} ->
+    Enum.with_index(scenarios)
+    |> Enum.map(fn {scenario, test_number} ->
       quote do
-        describe "#{unquote test_number}. #{unquote scenario.name}" do
+        describe "#{unquote(test_number)}. #{unquote(scenario.name)}" do
           @scenario unquote(Macro.escape(scenario))
           setup context do
             for tag <- unquote(scenario.tags) do
               case tag do
                 {tag, _value} ->
-                  Cabbage.Feature.Helpers.run_tag(unquote(Macro.escape(tags)), tag, unquote(env.module), unquote(scenario.name))
+                  Cabbage.Feature.Helpers.run_tag(
+                    unquote(Macro.escape(tags)),
+                    tag,
+                    unquote(env.module),
+                    unquote(scenario.name)
+                  )
+
                 tag ->
-                  Cabbage.Feature.Helpers.run_tag(unquote(Macro.escape(tags)), tag, unquote(env.module), unquote(scenario.name))
+                  Cabbage.Feature.Helpers.run_tag(
+                    unquote(Macro.escape(tags)),
+                    tag,
+                    unquote(env.module),
+                    unquote(scenario.name)
+                  )
               end
             end
-            {:ok, Map.merge(Cabbage.Feature.Helpers.fetch_state(unquote(scenario.name), __MODULE__), context || %{})}
+
+            {:ok,
+             Map.merge(
+               Cabbage.Feature.Helpers.fetch_state(unquote(scenario.name), __MODULE__),
+               context || %{}
+             )}
           end
 
           @tag :integration
           tags = unquote(Macro.escape(map_tags(scenario.tags))) || []
-          ExUnit.Case.register_test(unquote(Macro.escape(%{env | line: scenario.line})), :test, :cabbage_test, tags)
+
+          ExUnit.Case.register_test(
+            unquote(Macro.escape(%{env | line: scenario.line})),
+            :test,
+            :cabbage_test,
+            tags
+          )
+
           def unquote(:"test #{test_number}. #{scenario.name} cabbage_test")(exunit_state) do
             Cabbage.Feature.Helpers.start_state(unquote(scenario.name), __MODULE__, exunit_state)
-            Logger.info [IO.ANSI.color(61), "Line ", to_string(unquote(scenario.line)), ":  ", IO.ANSI.magenta, "Scenario: ", IO.ANSI.yellow, unquote(scenario.name)]
-            unquote Enum.map(scenario.steps, &compile_step(&1, steps, scenario.name))
+
+            Logger.info([
+              IO.ANSI.color(61),
+              "Line ",
+              to_string(unquote(scenario.line)),
+              ":  ",
+              IO.ANSI.magenta(),
+              "Scenario: ",
+              IO.ANSI.yellow(),
+              unquote(scenario.name)
+            ])
+
+            unquote(Enum.map(scenario.steps, &compile_step(&1, steps, scenario.name)))
           end
         end
       end
@@ -207,36 +251,61 @@ defmodule Cabbage.Feature do
     |> compile(step, step_type, scenario_name)
   end
 
-  defp compile({:{}, _, [regex, vars, state_pattern, block, metadata]}, step, step_type, scenario_name) do
+  defp compile(
+         {:{}, _, [regex, vars, state_pattern, block, metadata]},
+         step,
+         step_type,
+         scenario_name
+       ) do
     {regex, _} = Code.eval_quoted(regex)
-    named_vars = extract_named_vars(regex, step.text) |> Map.merge(%{table: step.table_data, doc_string: step.doc_string})
+
+    named_vars =
+      extract_named_vars(regex, step.text)
+      |> Map.merge(%{table: step.table_data, doc_string: step.doc_string})
+
     quote generated: true do
       with {_type, unquote(vars)} <- {:variables, unquote(Macro.escape(named_vars))},
-           {_type, state = unquote(state_pattern)} <- {:state, Cabbage.Feature.Helpers.fetch_state(unquote(scenario_name), __MODULE__)}
-           do
-        new_state = case unquote(block) do
-                      {:ok, new_state} -> Map.merge(state, new_state)
-                      _ -> state
-                    end
-        Cabbage.Feature.Helpers.update_state(unquote(scenario_name), __MODULE__, fn(_) -> new_state end)
-        Logger.info ["\t\t", IO.ANSI.cyan, unquote(step_type), " ", IO.ANSI.green, unquote(step.text)]
+           {_type, state = unquote(state_pattern)} <-
+             {:state, Cabbage.Feature.Helpers.fetch_state(unquote(scenario_name), __MODULE__)} do
+        new_state =
+          case unquote(block) do
+            {:ok, new_state} -> Map.merge(state, new_state)
+            _ -> state
+          end
+
+        Cabbage.Feature.Helpers.update_state(unquote(scenario_name), __MODULE__, fn _ ->
+          new_state
+        end)
+
+        Logger.info([
+          "\t\t",
+          IO.ANSI.cyan(),
+          unquote(step_type),
+          " ",
+          IO.ANSI.green(),
+          unquote(step.text)
+        ])
       else
         {type, state} ->
           metadata = unquote(Macro.escape(metadata))
+
           reraise """
-          ** (MatchError) Failure to match #{type} of #{inspect Cabbage.Feature.Helpers.remove_hidden_state(state)}
-          Pattern: #{unquote(Macro.to_string(state_pattern))}
-          """, Cabbage.Feature.Helpers.stacktrace(__MODULE__, metadata)
+                  ** (MatchError) Failure to match #{type} of #{
+                    inspect(Cabbage.Feature.Helpers.remove_hidden_state(state))
+                  }
+                  Pattern: #{unquote(Macro.to_string(state_pattern))}
+                  """,
+                  Cabbage.Feature.Helpers.stacktrace(__MODULE__, metadata)
       end
     end
   end
 
   defp compile(_, step, step_type, _scenario_name) do
-    raise MissingStepError, [step_text: step.text, step_type: step_type]
+    raise MissingStepError, step_text: step.text, step_type: step_type
   end
 
   defp find_implementation_of_step(step, steps) do
-    Enum.find(steps, fn ({:{}, _, [r, _, _, _, _]}) ->
+    Enum.find(steps, fn {:{}, _, [r, _, _, _, _]} ->
       step.text =~ r |> Code.eval_quoted() |> elem(0)
     end)
   end
@@ -286,19 +355,19 @@ defmodule Cabbage.Feature do
     end
   end
 
-  defmacro defgiven(regex, vars, state, [do: block]) do
+  defmacro defgiven(regex, vars, state, do: block) do
     add_step(__CALLER__.module, regex, vars, state, block, metadata(__CALLER__, :defgiven))
   end
 
-  defmacro defand(regex, vars, state, [do: block]) do
+  defmacro defand(regex, vars, state, do: block) do
     add_step(__CALLER__.module, regex, vars, state, block, metadata(__CALLER__, :defand))
   end
 
-  defmacro defwhen(regex, vars, state, [do: block]) do
+  defmacro defwhen(regex, vars, state, do: block) do
     add_step(__CALLER__.module, regex, vars, state, block, metadata(__CALLER__, :defwhen))
   end
 
-  defmacro defthen(regex, vars, state, [do: block]) do
+  defmacro defthen(regex, vars, state, do: block) do
     add_step(__CALLER__.module, regex, vars, state, block, metadata(__CALLER__, :defthen))
   end
 
@@ -319,7 +388,7 @@ defmodule Cabbage.Feature do
         end
       end
   """
-  defmacro tag(tag, [do: block]) do
+  defmacro tag(tag, do: block) do
     add_tag(__CALLER__.module, Macro.to_string(tag) |> String.replace(~r/\s*/, ""), block)
   end
 end

--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -184,11 +184,9 @@ defmodule Cabbage.Feature do
             {:ok, Map.merge(Cabbage.Feature.Helpers.fetch_state(unquote(scenario.name), __MODULE__), context || %{})}
           end
 
-          ExUnit.Case.register_test(unquote(Macro.escape(%{env | line: scenario.line})), :test, :cabbage_test, [])
+          tags = unquote(Macro.escape(scenario.tags |> Enum.map(&String.to_atom/1))) || []
+          ExUnit.Case.register_test(unquote(Macro.escape(%{env | line: scenario.line})), :test, :cabbage_test, tags)
           @tag :integration
-          for tag <- unquote(scenario.tags) do
-            Module.put_attribute(__MODULE__, String.to_atom(tag), true)
-          end
           def unquote(:"test #{test_number}. #{scenario.name} cabbage_test")(exunit_state) do
             Cabbage.Feature.Helpers.start_state(unquote(scenario.name), __MODULE__, exunit_state)
             Logger.info [IO.ANSI.color(61), "Line ", to_string(unquote(scenario.line)), ":  ", IO.ANSI.magenta, "Scenario: ", IO.ANSI.yellow, unquote(scenario.name)]

--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -172,21 +172,19 @@ defmodule Cabbage.Feature do
           @scenario unquote(Macro.escape(scenario))
           setup context do
             for tag <- unquote(scenario.tags) do
-              case Enum.find(unquote(Macro.escape(tags)), &(match?({^tag, _}, &1))) do
-                {^tag, block} ->
-                  Logger.debug "Cabbage: Running tag @#{tag}..."
-                  state = Cabbage.Feature.Helpers.evaluate_tag_block(block)
-                  Cabbage.Feature.Helpers.start_state(unquote(scenario.name), __MODULE__, state)
-                _ ->
-                  nil # Nothing to do
+              case tag do
+                {tag, _value} ->
+                  Cabbage.Feature.Helpers.run_tag(unquote(Macro.escape(tags)), tag, unquote(env.module), unquote(scenario.name))
+                tag ->
+                  Cabbage.Feature.Helpers.run_tag(unquote(Macro.escape(tags)), tag, unquote(env.module), unquote(scenario.name))
               end
             end
             {:ok, Map.merge(Cabbage.Feature.Helpers.fetch_state(unquote(scenario.name), __MODULE__), context || %{})}
           end
 
-          tags = unquote(Macro.escape(scenario.tags |> Enum.map(&String.to_atom/1))) || []
-          ExUnit.Case.register_test(unquote(Macro.escape(%{env | line: scenario.line})), :test, :cabbage_test, tags)
           @tag :integration
+          tags = unquote(Macro.escape(map_tags(scenario.tags))) || []
+          ExUnit.Case.register_test(unquote(Macro.escape(%{env | line: scenario.line})), :test, :cabbage_test, tags)
           def unquote(:"test #{test_number}. #{scenario.name} cabbage_test")(exunit_state) do
             Cabbage.Feature.Helpers.start_state(unquote(scenario.name), __MODULE__, exunit_state)
             Logger.info [IO.ANSI.color(61), "Line ", to_string(unquote(scenario.line)), ":  ", IO.ANSI.magenta, "Scenario: ", IO.ANSI.yellow, unquote(scenario.name)]

--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -209,8 +209,7 @@ defmodule Cabbage.Feature do
              )}
           end
 
-          @tag :integration
-          tags = unquote(Macro.escape(map_tags(scenario.tags))) || []
+          tags = unquote(Macro.escape(map_tags(Cabbage.global_tags() ++ scenario.tags))) || []
 
           ExUnit.Case.register_test(
             unquote(Macro.escape(%{env | line: scenario.line})),

--- a/lib/cabbage/feature/helpers.ex
+++ b/lib/cabbage/feature/helpers.ex
@@ -65,4 +65,25 @@ defmodule Cabbage.Feature.Helpers do
     |> Agent.update(fun)
   end
 
+  def run_tag(tags, tag, module, scenario_name) do
+    string_tag = to_string(tag)
+    case Enum.find(tags, &(match?({^string_tag, _}, &1))) do
+      {^string_tag, block} ->
+        Logger.debug "Cabbage: Running tag @#{tag}..."
+        state = evaluate_tag_block(block)
+        start_state(scenario_name, module, state)
+      _ ->
+        nil # Nothing to do
+    end
+  end
+
+  def map_tags(tags) do
+    tags
+    |> Enum.map(fn
+      {tag, value} ->
+        [{tag, value}]
+      tag ->
+        tag
+    end)
+  end
 end

--- a/lib/missing_step_error.ex
+++ b/lib/missing_step_error.ex
@@ -25,7 +25,7 @@ defmodule MissingStepError do
     Please add a matching step for:
     "#{step_type} #{step_text}"
 
-      def#{step_type |> String.downcase} ~r/^#{converted_step_text}$/, #{map_of_vars}, state do
+      def#{step_type |> String.downcase()} ~r/^#{converted_step_text}$/, #{map_of_vars}, state do
         # Your implementation here
       end
     """
@@ -66,7 +66,7 @@ defmodule MissingStepError do
     join_regex_split(tail, count + 1, type, {step_text, vars})
   end
 
-  defp get_regex_capture_string(:number, count),              do: ~s/ (?<number_#{count}>\\d+) /
+  defp get_regex_capture_string(:number, count), do: ~s/ (?<number_#{count}>\\d+) /
   defp get_regex_capture_string(:single_quote_string, count), do: ~s/'(?<string_#{count}>[^']+)'/
   defp get_regex_capture_string(:double_quote_string, count), do: ~s/"(?<string_#{count}>[^"]+)"/
 
@@ -75,10 +75,11 @@ defmodule MissingStepError do
   defp get_var_string(:double_quote_string, count), do: "string_#{count}"
 
   defp vars_to_correct_format([]), do: "_vars"
+
   defp vars_to_correct_format(vars) do
     joined_vars =
       vars
-      |> Enum.map(fn(var) -> "#{var}: #{var}" end)
+      |> Enum.map(fn var -> "#{var}: #{var}" end)
       |> Enum.join(", ")
 
     "%{#{joined_vars}}"

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Cabbage.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:gherkin, "~> 1.4"},
+      {:gherkin, "~> 1.6"},
       {:ex_doc, "~> 0.18", only: :dev},
       {:earmark, "~> 1.2", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "gherkin": {:hex, :gherkin, "1.5.0", "c2793b02777783c5ee2e52468a80d43eccde629250564702d78763dbd00ef7ed", [:mix], [], "hexpm"}}
+  "gherkin": {:hex, :gherkin, "1.6.0", "a7a2925e6153b7f475646e411e45eed657eb8648ae4bec4222334bf46d37798e", [:mix], [], "hexpm"}}

--- a/test/changing_names_test.exs
+++ b/test/changing_names_test.exs
@@ -12,7 +12,4 @@ defmodule Cabbage.ChangingNamesTest do
   defthen ~r/^my name is "(?<name>[^"]+)"$/, %{name: name}, %{username: username} do
     assert username == name
   end
-
-
-
 end

--- a/test/changing_state_test.exs
+++ b/test/changing_state_test.exs
@@ -1,7 +1,7 @@
 defmodule Cabbage.ChangingStateTest do
   use Cabbage.Feature, async: true, file: "changing_state.feature"
 
-  setup context do
+  setup _context do
     {:ok, params: %{start: :state}}
   end
 
@@ -14,7 +14,7 @@ defmodule Cabbage.ChangingStateTest do
     {:ok, state}
   end
 
-  defwhen ~r/^I change the state$/, _vars, state do
+  defwhen ~r/^I change the state$/, _vars, _state do
     {:ok, %{params: %{new: :state}}}
   end
 

--- a/test/data_tables_test.exs
+++ b/test/data_tables_test.exs
@@ -1,7 +1,9 @@
 defmodule Cabbage.DataTableTest do
   use Cabbage.Feature, file: "data_tables.feature"
 
-  defgiven ~r/^the following data table$/, %{table: [%{id: "1", name: "Luke"}, %{id: "2", name: "Darth"}]}, _state do
+  defgiven ~r/^the following data table$/,
+           %{table: [%{id: "1", name: "Luke"}, %{id: "2", name: "Darth"}]},
+           _state do
     :ok
   end
 
@@ -9,7 +11,9 @@ defmodule Cabbage.DataTableTest do
     :ok
   end
 
-  defthen ~r/^in the step definition I should get a var with the value$/, %{doc_string: string}, _state do
+  defthen ~r/^in the step definition I should get a var with the value$/,
+          %{doc_string: string},
+          _state do
     assert ~s([%{id: "1", name: "Luke"}, %{id: "2", name: "Darth"}]) == String.trim(string)
   end
 end

--- a/test/feature_test.exs
+++ b/test/feature_test.exs
@@ -3,8 +3,8 @@ defmodule Cabbage.FeatureTest do
   alias Gherkin.Elements.Scenario
   doctest Cabbage.Feature
 
-  import_feature Cabbage.GlobalFeatures
-  import_steps Cabbage.TaglessFeatures
+  import_feature(Cabbage.GlobalFeatures)
+  import_steps(Cabbage.TaglessFeatures)
 
   test "has an @feature" do
     assert "Serve coffee" = @feature.name

--- a/test/feature_test.exs
+++ b/test/feature_test.exs
@@ -28,5 +28,4 @@ defmodule Cabbage.FeatureTest do
     assert coffees - 1 < 0
     {:ok, %{coffees: coffees - 1}}
   end
-
 end

--- a/test/features/tags.feature
+++ b/test/features/tags.feature
@@ -8,3 +8,9 @@ Scenario: Run test for a scenario tagged as @wip
   Given a scenario is tagged as "@wip"
   When run mix test --only wip some_test.exs
   Then this test should be marked with that tag
+
+@skip
+Scenario: Skipping tests
+  Given a scenario is tagged as "@skip"
+  When run mix test
+  Then this test should be skipped and never run

--- a/test/features/tags.feature
+++ b/test/features/tags.feature
@@ -7,7 +7,7 @@ Feature: Tag Scenario
   Scenario: Run test for a scenario tagged as @wip
     Given a scenario is tagged as "@wip"
     When run mix test --only wip some_test.exs
-    Then this test should be marked with that tag
+    Then this test should be marked with "@wip" tag
 
   @skip
   Scenario: Skipping tests
@@ -20,3 +20,8 @@ Feature: Tag Scenario
     Given a scenario is tagged as "@timeout"
     When it takes longer than the timeout
     Then the test fails
+
+  Scenario: Run test for a scenario tagged as @global_integration_test
+    Given global tag is set to "@global_integration_test"
+    When run mix test --only "@global_integration_test" some_test.exs
+    Then this test should be marked with "@global_integration_test" tag

--- a/test/features/tags.feature
+++ b/test/features/tags.feature
@@ -1,0 +1,10 @@
+Feature: Tag Scenario
+  As a Product Manager/Developer
+  I want to add tags to a scenario in a feature file
+  So I can do stuff with the steps implementation based on tags
+
+@wip
+Scenario: Run test for a scenario tagged as @wip
+  Given a scenario is tagged as "@wip"
+  When run mix test --only wip some_test.exs
+  Then this test should be marked with that tag

--- a/test/features/tags.feature
+++ b/test/features/tags.feature
@@ -3,14 +3,20 @@ Feature: Tag Scenario
   I want to add tags to a scenario in a feature file
   So I can do stuff with the steps implementation based on tags
 
-@wip
-Scenario: Run test for a scenario tagged as @wip
-  Given a scenario is tagged as "@wip"
-  When run mix test --only wip some_test.exs
-  Then this test should be marked with that tag
+  @wip
+  Scenario: Run test for a scenario tagged as @wip
+    Given a scenario is tagged as "@wip"
+    When run mix test --only wip some_test.exs
+    Then this test should be marked with that tag
 
-@skip
-Scenario: Skipping tests
-  Given a scenario is tagged as "@skip"
-  When run mix test
-  Then this test should be skipped and never run
+  @skip
+  Scenario: Skipping tests
+    Given a scenario is tagged as "@skip"
+    When run mix test
+    Then this test should be skipped and never run
+
+  @timeout 1000
+  Scenario: Chanage the timeout value
+    Given a scenario is tagged as "@timeout"
+    When it takes longer than the timeout
+    Then the test fails

--- a/test/missing_step_error_test.exs
+++ b/test/missing_step_error_test.exs
@@ -4,6 +4,7 @@ defmodule MissingStepAdvisorTest do
   test "raises RuntimeError if step is missing" do
     step_text = "I am Bob"
     step_type = "Given"
+
     expected_message = """
     Please add a matching step for:
     "Given I am Bob"
@@ -19,6 +20,7 @@ defmodule MissingStepAdvisorTest do
   test "convert double quote strings to regex capture group in message" do
     step_text = "my name is \"Miran\""
     step_type = "Given"
+
     expected_message = """
     Please add a matching step for:
     "Given my name is "Miran""
@@ -27,12 +29,14 @@ defmodule MissingStepAdvisorTest do
         # Your implementation here
       end
     """
+
     assert_correct_message(step_text, step_type, expected_message)
   end
 
   test "convert multiple double quote strings" do
     step_text = "my first name is \"Erol\" and my nickname is \"Hungry Homer\""
     step_type = "Given"
+
     expected_message = """
     Please add a matching step for:
     "Given my first name is "Erol" and my nickname is "Hungry Homer""
@@ -41,12 +45,14 @@ defmodule MissingStepAdvisorTest do
         # Your implementation here
       end
     """
+
     assert_correct_message(step_text, step_type, expected_message)
   end
 
   test "convert single quote strings to regex capture group in message" do
     step_text = "my name is 'Miran'"
     step_type = "Given"
+
     expected_message = """
     Please add a matching step for:
     "Given my name is 'Miran'"
@@ -62,6 +68,7 @@ defmodule MissingStepAdvisorTest do
   test "convert multiple single quote strings" do
     step_text = "my favourite food & drink is 'Cheese' and 'Liquid Cheese'"
     step_type = "And"
+
     expected_message = """
     Please add a matching step for:
     "And my favourite food & drink is 'Cheese' and 'Liquid Cheese'"
@@ -77,6 +84,7 @@ defmodule MissingStepAdvisorTest do
   test "convert numbers to regex capture group in message" do
     step_text = "I am 49 years old"
     step_type = "And"
+
     expected_message = """
     Please add a matching step for:
     "And I am 49 years old"
@@ -92,6 +100,7 @@ defmodule MissingStepAdvisorTest do
   test "converting numbers to regex capture group ignores numbers with letters" do
     step_text = "the 3rd number is 1101"
     step_type = "When"
+
     expected_message = """
     Please add a matching step for:
     "When the 3rd number is 1101"
@@ -107,6 +116,7 @@ defmodule MissingStepAdvisorTest do
   test "convert numbers to capture group where number is at the beginning" do
     step_text = "29 is my favourite number"
     step_type = "Given"
+
     expected_message = """
     Please add a matching step for:
     "Given 29 is my favourite number"
@@ -122,6 +132,7 @@ defmodule MissingStepAdvisorTest do
   test "convert multiple numbers to capture groups" do
     step_text = "there are 3 on the left and 2 on the right"
     step_type = "And"
+
     expected_message = """
     Please add a matching step for:
     "And there are 3 on the left and 2 on the right"
@@ -135,10 +146,12 @@ defmodule MissingStepAdvisorTest do
   end
 
   defp assert_correct_message(step_text, step_type, expected_message) do
-    assert_raise(MissingStepError,
-                 expected_message,
-                 fn ->
-                   raise MissingStepError, [step_text: step_text, step_type: step_type]
-                 end)
+    assert_raise(
+      MissingStepError,
+      expected_message,
+      fn ->
+        raise MissingStepError, step_text: step_text, step_type: step_type
+      end
+    )
   end
 end

--- a/test/outline_test.exs
+++ b/test/outline_test.exs
@@ -1,7 +1,7 @@
 defmodule Cabbage.OutlineTest do
   use Cabbage.Feature, file: "coffee_outline.feature"
 
-  import_feature Cabbage.GlobalFeatures
+  import_feature(Cabbage.GlobalFeatures)
 
   setup do
     {:ok, %{starting: :state}}

--- a/test/support/global_features.ex
+++ b/test/support/global_features.ex
@@ -5,19 +5,27 @@ defmodule Cabbage.GlobalFeatures do
     {:ok, %{tagged: :data}}
   end
 
-  tag @no-coffee do
-    nil # Works fine
+  tag @no - coffee do
+    # Works fine
+    nil
   end
 
   tag @last_chance do
-    :ok # Also works
+    # Also works
+    :ok
   end
 
-  defgiven ~r/^there are (?<number>\d+) coffees left in the machine$/, %{number: number}, %{starting: :state, tagged: :data} do
+  defgiven ~r/^there are (?<number>\d+) coffees left in the machine$/, %{number: number}, %{
+    starting: :state,
+    tagged: :data
+  } do
     {:ok, %{coffees: String.to_integer(number)}}
   end
 
-  defand ~r/^I have deposited \$(?<money>\d+)$/, %{money: money}, %{coffees: _coffees, tagged: :data} do
+  defand ~r/^I have deposited \$(?<money>\d+)$/, %{money: money}, %{
+    coffees: _coffees,
+    tagged: :data
+  } do
     {:ok, %{deposited: String.to_integer(money)}}
   end
 end

--- a/test/tags_test.exs
+++ b/test/tags_test.exs
@@ -6,10 +6,10 @@ defmodule Cabbage.TagsTest do
   end
 
   defwhen ~r/^run mix test --only wip some_test.exs$/, _vars, _state do
-    # Nothing to do here
+    # Nothing to do here, cannot replicate
   end
 
   defthen ~r/^this test should be marked with that tag$/, _vars, %{tag: _tag} do
-    # unable to do: Module.get_attribute(__MODULE__, String.to_atom(tag))
+    assert %ExUnit.Test{tags: %{wip: true}} = @ex_unit_tests |> hd()
   end
 end

--- a/test/tags_test.exs
+++ b/test/tags_test.exs
@@ -1,0 +1,15 @@
+defmodule Cabbage.TagsTest do
+  use Cabbage.Feature, file: "tags.feature"
+
+  defgiven ~r/^a scenario is tagged as "(?<tag>[^"]+)"$/, %{tag: tag}, _state do
+    {:ok, %{tag: tag}}
+  end
+
+  defwhen ~r/^run mix test --only wip some_test.exs$/, _vars, _state do
+    # Nothing to do here
+  end
+
+  defthen ~r/^this test should be marked with that tag$/, _vars, %{tag: _tag} do
+    # unable to do: Module.get_attribute(__MODULE__, String.to_atom(tag))
+  end
+end

--- a/test/tags_test.exs
+++ b/test/tags_test.exs
@@ -5,11 +5,15 @@ defmodule Cabbage.TagsTest do
     {:ok, %{tag: tag}}
   end
 
-  defwhen ~r/^run mix test --only wip some_test.exs$/, _vars, _state do
+  defwhen ~r/^run mix test( --only wip some_test.exs)?$/, _vars, _state do
     # Nothing to do here, cannot replicate
   end
 
   defthen ~r/^this test should be marked with that tag$/, _vars, %{tag: _tag} do
     assert %ExUnit.Test{tags: %{wip: true}} = @ex_unit_tests |> hd()
+  end
+
+  defthen ~r/^this test should be skipped and never run$/, _vars, state do
+    assert false
   end
 end

--- a/test/tags_test.exs
+++ b/test/tags_test.exs
@@ -10,11 +10,13 @@ defmodule Cabbage.TagsTest do
   end
 
   defwhen ~r/^it takes longer than the timeout$/, _vars, _state do
-    Process.sleep(0) # Change to 1500 to test
+    # Change to 1500 to test
+    Process.sleep(0)
   end
 
   defthen ~r/^the test fails$/, _vars, _state do
-    assert :ok # Not able to test
+    # Not able to test
+    assert :ok
   end
 
   defthen ~r/^this test should be marked with that tag$/, _vars, %{tag: _tag} do

--- a/test/tags_test.exs
+++ b/test/tags_test.exs
@@ -9,11 +9,19 @@ defmodule Cabbage.TagsTest do
     # Nothing to do here, cannot replicate
   end
 
+  defwhen ~r/^it takes longer than the timeout$/, _vars, _state do
+    Process.sleep(0) # Change to 1500 to test
+  end
+
+  defthen ~r/^the test fails$/, _vars, _state do
+    assert :ok # Not able to test
+  end
+
   defthen ~r/^this test should be marked with that tag$/, _vars, %{tag: _tag} do
     assert %ExUnit.Test{tags: %{wip: true}} = @ex_unit_tests |> hd()
   end
 
-  defthen ~r/^this test should be skipped and never run$/, _vars, state do
+  defthen ~r/^this test should be skipped and never run$/, _vars, _state do
     assert false
   end
 end

--- a/test/template_test.exs
+++ b/test/template_test.exs
@@ -1,6 +1,6 @@
 defmodule Cabbage.TemplateTest do
   use Cabbage.Feature, template: Cabbage.ExUnit.CaseTemplate, file: "coffee.feature"
-  import_feature Cabbage.GlobalFeatures
+  import_feature(Cabbage.GlobalFeatures)
 
   defwhen ~r/^I press the coffee button$/, _, %{case_template: template, deposited: deposited} do
     assert Cabbage.ExUnit.CaseTemplate = template


### PR DESCRIPTION
#34 and #54 should be merged so diff would be cleaner

Ability to provide a dynamic global tag.
Beforehand it was globally set to `@tag :integration`.

Now value would be fetched via `Application.get_env(:cabbage, :global_tags, [])`.
While now default value if isn't configured, is set to empty list, this could be changed for backwards compatibility to be `:integration`