### PR TITLE
suggesting doc_string and table, removed defand

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ defmodule MyApp.Features.CoffeeTest do
     %{my_starting: :state, user: %User{}} # Return some beginning state
   end
 
-  # All `defgiven/4`, `defand/4`, `defwhen/4` and `defthen/4` takes a regex, matched data, state and lastly a block
+  # All `defgiven/4`, `defwhen/4` and `defthen/4` takes a regex, matched data, state and lastly a block
   defgiven ~r/^there (is|are) (?<number>\d+) coffee(s) left in the machine$/, %{number: number}, %{user: user} do
     # `{:ok, state}` gets returned from each callback which updates the state or
     # leaves the state unchanged when something else is returned
     {:ok, %{machine: Machine.put_coffee(Machine.new, number)}}
   end
 
-  defand ~r/^I have deposited £(?<number>\d+)$/, %{number: number}, %{user: user, machine: machine} do
+  defgiven ~r/^I have deposited £(?<number>\d+)$/, %{number: number}, %{user: user, machine: machine} do
     {:ok, %{machine: Machine.deposit(machine, user, number)}} # State is automatically merged so this won't erase `user`
   end
 
@@ -77,7 +77,7 @@ defmodule MyApp.Features.CoffeeTest do
 
   # Since state is unchanged, its not necessary to return it
   defthen ~r/^I should be served a coffee$/, _, state do
-    assert %Coffee{} = Machine.take_drink(state.machine) # Make your `assert`ions in `defthen/4`s and `defand/4`s
+    assert %Coffee{} = Machine.take_drink(state.machine) # Make your `assert`ions in `defthen/4`s
   end
 end
 ```

--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -124,7 +124,7 @@ defmodule Cabbage.Feature do
   """
   import Cabbage.Feature.Helpers
 
-  alias Cabbage.Feature.Loader
+  alias Cabbage.Feature.{Loader, MissingStepError}
 
   @feature_options [:file, :template]
   defmacro __using__(options) do
@@ -315,7 +315,9 @@ defmodule Cabbage.Feature do
   end
 
   defp compile(_, step, step_type, _scenario_name) do
-    raise MissingStepError, step_text: step.text, step_type: step_type
+    extra_vars = %{table: step.table_data, doc_string: step.doc_string}
+
+    raise MissingStepError, step_text: step.text, step_type: step_type, extra_vars: extra_vars
   end
 
   defp find_implementation_of_step(step, steps) do

--- a/lib/cabbage/feature/loader.ex
+++ b/lib/cabbage/feature/loader.ex
@@ -1,0 +1,33 @@
+defmodule Cabbage.Feature.Loader do
+  alias Gherkin.Elements.{Feature, Scenario, Steps}
+
+  def load_from_file(path) do
+    "#{Cabbage.base_path()}#{path}"
+    |> File.read!()
+    |> load_from_string()
+  end
+
+  def load_from_string(string) do
+    string
+    |> Gherkin.parse()
+    |> Gherkin.flatten()
+    |> fix_step_types()
+  end
+
+  defp fix_step_types(%Feature{scenarios: scenarios} = feature) do
+    scenarios = scenarios |> Enum.map(&fix_step_types/1)
+    %{feature | scenarios: scenarios}
+  end
+
+  defp fix_step_types(%Scenario{steps: steps} = scenario) do
+    steps = steps |> Enum.reduce([], &fix_step_type/2) |> Enum.reverse()
+    %{scenario | steps: steps}
+  end
+
+  defp fix_step_type(%Steps.And{} = current_step, [previous_step | _] = steps) do
+    fixed_step = %{current_step | __struct__: previous_step.__struct__}
+    [fixed_step | steps]
+  end
+
+  defp fix_step_type(current_step, steps), do: [current_step | steps]
+end

--- a/lib/cabbage/feature/missing_step_error.ex
+++ b/lib/cabbage/feature/missing_step_error.ex
@@ -1,4 +1,4 @@
-defmodule MissingStepError do
+defmodule Cabbage.Feature.MissingStepError do
   @moduledoc """
   Raises an error, because a feature step is missing its implementation.
 
@@ -12,12 +12,13 @@ defmodule MissingStepError do
   @single_quote_regex ~r/'[^']+'/
   @double_quote_regex ~r/"[^"]+"/
 
-  def exception(step_text: step_text, step_type: step_type) do
+  def exception(step_text: step_text, step_type: step_type, extra_vars: extra_vars) do
     {converted_step_text, list_of_vars} =
       {step_text, []}
       |> convert_nums()
       |> convert_double_quote_strings()
       |> convert_single_quote_strings()
+      |> convert_extra_vars(extra_vars)
 
     map_of_vars = vars_to_correct_format(list_of_vars)
 
@@ -49,6 +50,13 @@ defmodule MissingStepError do
     @single_quote_regex
     |> Regex.split(step_text)
     |> join_regex_split(1, :single_quote_string, {"", vars})
+  end
+
+  defp convert_extra_vars({step_text, vars}, %{doc_string: doc_string, table: table}) do
+    vars = if doc_string == "", do: vars, else: vars ++ ["doc_string"]
+    vars = if table == [], do: vars, else: vars ++ ["table"]
+
+    {step_text, vars}
   end
 
   defp join_regex_split([], _count, _type, {acc, vars}) do

--- a/test/feature_execution_test.exs
+++ b/test/feature_execution_test.exs
@@ -110,7 +110,7 @@ defmodule Cabbage.FeatureExecutionTest do
           assert doc_string == complex_string
         end
 
-        defthen ~r/^I provide And with \"(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part and with docs part$/,
+        defthen ~r/^I provide And with \"(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part and with table part$/,
                 %{string_1: string_1, string_2: string_2, table: table},
                 _state do
           assert string_1 == "and dynamic"

--- a/test/feature_execution_test.exs
+++ b/test/feature_execution_test.exs
@@ -16,7 +16,7 @@ defmodule Cabbage.FeatureExecutionTest do
           [:given | state]
         end
 
-        defand ~r/^I provide And$/, _vars, %{state: state} do
+        defgiven ~r/^I provide And$/, _vars, %{state: state} do
           assert [:initial] == state
           nil
         end

--- a/test/feature_suggestion_test.exs
+++ b/test/feature_suggestion_test.exs
@@ -21,20 +21,12 @@ defmodule Cabbage.FeatureSuggestionTest do
       end
     end
 
-    @doc """
-    TODO: Doesn't suggest correct part line.
-    defand shouldn't even exist.
-    As in different scenarios the same given and any other term could be provided in different orders, so in one scenario it could be:
-    `Given user have milk`, but in other `And user have milk`.
-    Both should be `defgiven "user have milk", _vars, _state do`
-    As i understand defgive, defwhen, defthen and defand all work exaclty the same and there even isn't any difference between them.
-    """
     test "Show missing And step" do
       message = """
       Please add a matching step for:
-      "And I provide And"
+      "Given I provide And"
 
-        defand ~r/^I provide And$/, _vars, state do
+        defgiven ~r/^I provide And$/, _vars, state do
           # Your implementation here
         end
       """
@@ -201,15 +193,14 @@ defmodule Cabbage.FeatureSuggestionTest do
     end
 
     @doc """
-    TODO: This test doesn't work because of suggested is `defand` not `defthen`
     TODO: This test doens't work because of missing `doc_string` in `vars`
     """
     test "Show missing dynamic And step with three dynamic parts one of which is docs" do
       message = """
       Please add a matching step for:
-      "And I provide And with \"and dynamic\" part and with one more \"another and dynamic\" part and with docs part"
+      "Then I provide And with \"and dynamic\" part and with one more \"another and dynamic\" part and with docs part"
 
-        defand ~r/^I provide And with "(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part and with docs part$/, %{string_1: string_1, string_2: string_2}, state do
+        defthen ~r/^I provide And with "(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part and with docs part$/, %{string_1: string_1, string_2: string_2}, state do
           # Your implementation here
         end
       """

--- a/test/feature_suggestion_test.exs
+++ b/test/feature_suggestion_test.exs
@@ -3,6 +3,8 @@ Code.require_file("test_helper.exs", __DIR__)
 defmodule Cabbage.FeatureSuggestionTest do
   use ExUnit.Case
 
+  alias Cabbage.Feature.MissingStepError
+
   describe "provide simple missing steps" do
     test "Show missing Given step" do
       message = """
@@ -161,16 +163,12 @@ defmodule Cabbage.FeatureSuggestionTest do
       end
     end
 
-    @doc """
-    TODO: Sugesting doesn't suggest correct code, if part has extra docs line
-    Missing `doc_string: doc_string` in `_vars`
-    """
     test "Show missing dynamic Then step with two dynamic parts one of which is docs" do
       message = """
       Please add a matching step for:
       "Then I provide Then with number 6 part and with docs part\"
 
-        defthen ~r/^I provide Then with number (?<number_1>\d+) part and with docs part$/, %{number_1: number_1}, state do
+        defthen ~r/^I provide Then with number (?<number_1>\d+) part and with docs part$/, %{number_1: number_1, doc_string: doc_string}, state do
           # Your implementation here
         end
       """
@@ -192,15 +190,12 @@ defmodule Cabbage.FeatureSuggestionTest do
       end
     end
 
-    @doc """
-    TODO: This test doens't work because of missing `doc_string` in `vars`
-    """
     test "Show missing dynamic And step with three dynamic parts one of which is docs" do
       message = """
       Please add a matching step for:
-      "Then I provide And with \"and dynamic\" part and with one more \"another and dynamic\" part and with docs part"
+      "Then I provide And with \"and dynamic\" part and with one more \"another and dynamic\" part and with table part"
 
-        defthen ~r/^I provide And with "(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part and with docs part$/, %{string_1: string_1, string_2: string_2}, state do
+        defthen ~r/^I provide And with "(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part and with table part$/, %{string_1: string_1, string_2: string_2, table: table}, state do
           # Your implementation here
         end
       """
@@ -248,8 +243,8 @@ defmodule Cabbage.FeatureSuggestionTest do
           # Your implementation here
         end
 
-        defthen ~r/^I provide And with \"(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part and with docs part$/,
-                %{string_1: _string_1, string_2: _string_2, doc_string: _doc_string},
+        defthen ~r/^I provide And with \"(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part and with table part$/,
+                %{string_1: _string_1, string_2: _string_2, table: _table},
                 _state do
           # Your implementation here
         end

--- a/test/features/dynamic.feature
+++ b/test/features/dynamic.feature
@@ -8,7 +8,7 @@ Feature: Can have complex features
       """
       Here is provided some complex part that is way to complex
       """
-    And I provide And with "and dynamic" part and with one more "another and dynamic" part and with docs part
+    And I provide And with "and dynamic" part and with one more "another and dynamic" part and with table part
       | Name | Age |
       | John | 30 |
       | Ann | 29 |


### PR DESCRIPTION
- Improved missing steps suggestions. Now suggested code shows `doc_string` and `table` vars if relevant.
- Removed `defand`, as contextually every `And` step in `.feature` is just for readability purposes. In the end `And` means continue the same context (`Given`, `When`, `Then`)