### PR TITLE
Implemented Backgrounds for Features/Scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ defmodule MyApp.Features.CoffeeTest do
 
   # `setup_all/1` provides a callback for doing something before the entire suite runs
   # As below, `setup/1` provides means of doing something prior to each scenario
+  # Note that ExUnit preserves the order of `setup/1` callbacks. That means if you use a Background section,
+  # the steps for the Background section will execute before the `setup/1` callback has a chance to execute.
   setup do
     on_exit fn -> # Do something when the scenario is done
       IO.puts "Scenario completed, cleanup stuff"

--- a/README.md
+++ b/README.md
@@ -158,6 +158,6 @@ $ docker-compose run --rm cabbage test test/feature_test.exs
 - [x] Data tables
 - [x] Executing specific tests
 - [x] Tags implementation
-- [ ] Background steps
+- [x] Background steps
 - [ ] Integration Helpers for Wallaby (separate project?)
 - [ ] Integration Helpers for Hound (separate project?)

--- a/README.md
+++ b/README.md
@@ -159,5 +159,6 @@ $ docker-compose run --rm cabbage test test/feature_test.exs
 - [x] Executing specific tests
 - [x] Tags implementation
 - [x] Background steps
+- [x] Rules
 - [ ] Integration Helpers for Wallaby (separate project?)
 - [ ] Integration Helpers for Hound (separate project?)

--- a/lib/cabbage/describe_block.ex
+++ b/lib/cabbage/describe_block.ex
@@ -1,0 +1,4 @@
+defmodule Cabbage.DescribeBlock do
+  @moduledoc false
+  defstruct description: "", background_steps: [], scenario: nil 
+end

--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -184,7 +184,7 @@ defmodule Cabbage.Feature do
     steps = Module.get_attribute(env.module, :steps) || []
     tags = Module.get_attribute(env.module, :tags) || []
 
-    Enum.with_index(scenarios)
+    Enum.with_index(scenarios, 1)
     |> Enum.map(fn {scenario, test_number} ->
       scenario =
         Map.put(

--- a/lib/cabbage/feature/loader.ex
+++ b/lib/cabbage/feature/loader.ex
@@ -1,5 +1,5 @@
 defmodule Cabbage.Feature.Loader do
-  alias Gherkin.Elements.{Feature, Scenario, Steps}
+  alias Gherkin.Elements.{Feature, Scenario, Step}
 
   def load_from_file(path) do
     "#{Cabbage.base_path()}#{path}"
@@ -24,8 +24,8 @@ defmodule Cabbage.Feature.Loader do
     %{scenario | steps: steps}
   end
 
-  defp fix_step_type(%Steps.And{} = current_step, [previous_step | _] = steps) do
-    fixed_step = %{current_step | __struct__: previous_step.__struct__}
+  defp fix_step_type(%Step{keyword: "And"} = current_step, [previous_step | _] = steps) do
+    fixed_step = %{current_step | keyword: previous_step.keyword}
     [fixed_step | steps]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Cabbage.Mixfile do
   use Mix.Project
 
-  @version "0.3.6"
+  @version "0.4.0"
   def project do
     [
       app: :cabbage,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Cabbage.Mixfile do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.5.0"
   def project do
     [
       app: :cabbage,

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Cabbage.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:gherkin, "~> 1.6"},
+      {:gherkin, github: "mononym/gherkin", tag: "v2.0.0"},
       {:ex_doc, "~> 0.19", only: :dev},
       {:earmark, "~> 1.2", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "gherkin": {:hex, :gherkin, "1.6.0", "a7a2925e6153b7f475646e411e45eed657eb8648ae4bec4222334bf46d37798e", [:mix], [], "hexpm"},
+  "gherkin": {:git, "https://github.com/mononym/gherkin.git", "901028b1891d3fb9713b1e300da1a0dab7200215", [tag: "v2.0.0"]},
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},

--- a/test/feature_background_test.exs
+++ b/test/feature_background_test.exs
@@ -1,0 +1,24 @@
+Code.require_file("test_helper.exs", __DIR__)
+
+defmodule Cabbage.FeatureBackgroundTest do
+  use ExUnit.Case
+
+  describe "Features can have state setup by a Background" do
+    test "Checks that Background was properly run" do
+      defmodule FeatureBackgroundTest do
+        use Cabbage.Feature, file: "background.feature"
+
+        defgiven ~r/^I provide Background$/, _vars, _state do
+          {:ok, %{background: true}}
+        end
+
+        defthen ~r/^I provided Background$/, _vars, %{background: background} = _state do
+          assert background
+        end
+      end
+
+      {result, _output} = CabbageTestHelper.run()
+      assert result == %{failures: 0, skipped: 0, total: 2, excluded: 0}
+    end
+  end
+end

--- a/test/feature_rule_test.exs
+++ b/test/feature_rule_test.exs
@@ -1,0 +1,32 @@
+Code.require_file("test_helper.exs", __DIR__)
+
+defmodule Cabbage.FeatureRuleTest do
+  use ExUnit.Case
+
+  describe "Rules share a common background, but can also stack their own on" do
+    test "Checks that Background was properly run" do
+      defmodule FeatureRuleTest do
+        use Cabbage.Feature, file: "rule.feature"
+
+        defgiven ~r/^I provide Background$/, _vars, _state do
+          {:ok, %{background: true}}
+        end
+
+        defgiven ~r/^I provide additional Background$/, _vars, %{background: _background} = _state do
+          {:ok, %{additional_background: true}}
+        end
+
+        defthen ~r/^I provided Background$/, _vars, %{background: background} = _state do
+          assert background
+        end
+
+        defthen ~r/^I provided additional Background$/, _vars, %{additional_background: background} = _state do
+          assert background
+        end
+      end
+
+      {result, _output} = CabbageTestHelper.run()
+      assert result == %{failures: 0, skipped: 0, total: 2, excluded: 0}
+    end
+  end
+end

--- a/test/features/background.feature
+++ b/test/features/background.feature
@@ -1,0 +1,11 @@
+Feature: Background works for Scenarios
+  Tests that Background sets up state
+
+  Background:
+    Given I provide Background
+
+  Scenario: Background provides default state
+    Then I provided Background
+
+  Scenario: Background provides default state again
+    Then I provided Background

--- a/test/features/rule.feature
+++ b/test/features/rule.feature
@@ -1,0 +1,19 @@
+Feature: Rule feature works
+  Tests that miultiple Rules work with backgrounds of all kinds.
+
+  Background:
+    Given I provide Background
+
+  Rule: First rule has no additional background
+
+    Scenario: Background provides default state
+      Then I provided Background
+
+  Rule: Second rule provides additional background
+
+    Background:
+      Given I provide additional Background
+
+    Scenario: Background provides default state again
+      Then I provided Background
+      And I provided additional Background

--- a/test/features/rule.feature
+++ b/test/features/rule.feature
@@ -1,5 +1,5 @@
 Feature: Rule feature works
-  Tests that miultiple Rules work with backgrounds of all kinds.
+  Tests that multiple Rules work with backgrounds of all kinds.
 
   Background:
     Given I provide Background


### PR DESCRIPTION
The addition of 'IO.ANSI.white()' to the end of the log lines keeps the configured color from bleeding over into the beginning of the next log line.

Version was bumped because there was new functionality added which can change the behavior of tests.

Test 0 makes no sense, so tests now begin at 1.

It might be worth calling out in the docs somewhere that any tags that are run before the tests are run before the background steps are run. Background steps have access to any context set by an explicit 'setup_all' callback. Note that due to the preservation of order for 'setup' callbacks by ExUnit, any 'setup' callback defined explicitly in the test module will be run *after* the setup block automatically generated by cabbage which contains the tag and background steps.