### PR TITLE
Make missing steps be test failures

### DIFF
--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -309,9 +309,13 @@ defmodule Cabbage.Feature do
   end
 
   defp compile(_, step, step_type, _scenario_name) do
-    extra_vars = %{table: step.table_data, doc_string: step.doc_string}
+    step_text = step.text
+    table = Macro.escape(step.table_data)
+    doc_string = step.doc_string
 
-    raise MissingStepError, step_text: step.text, step_type: step_type, extra_vars: extra_vars
+    quote generated: true do
+      raise MissingStepError, [step_text: unquote(step_text), step_type: unquote(step_type), extra_vars: %{table: unquote(table), doc_string: unquote(doc_string)}]
+    end
   end
 
   defp find_implementation_of_step(step, steps) do

--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -275,6 +275,14 @@ defmodule Cabbage.Feature do
       with {_type, unquote(vars)} <- {:variables, unquote(Macro.escape(named_vars))},
            {_type, state = unquote(state_pattern)} <-
              {:state, Cabbage.Feature.Helpers.fetch_state(unquote(scenario_name), __MODULE__)} do
+        Logger.warn([
+          "\t\t",
+          IO.ANSI.cyan(),
+          unquote(step_type),
+          " ",
+          IO.ANSI.green(),
+          unquote(step.text)
+        ])
         new_state =
           case unquote(block) do
             {:ok, new_state} -> Map.merge(state, new_state)
@@ -285,14 +293,6 @@ defmodule Cabbage.Feature do
           new_state
         end)
 
-        Logger.warn([
-          "\t\t",
-          IO.ANSI.cyan(),
-          unquote(step_type),
-          " ",
-          IO.ANSI.green(),
-          unquote(step.text)
-        ])
       else
         {type, state} ->
           metadata = unquote(Macro.escape(metadata))

--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -285,7 +285,7 @@ defmodule Cabbage.Feature do
           new_state
         end)
 
-        Logger.info([
+        Logger.warn([
           "\t\t",
           IO.ANSI.cyan(),
           unquote(step_type),

--- a/test/feature_suggestion_test.exs
+++ b/test/feature_suggestion_test.exs
@@ -3,99 +3,109 @@ Code.require_file("test_helper.exs", __DIR__)
 defmodule Cabbage.FeatureSuggestionTest do
   use ExUnit.Case
 
-  alias Cabbage.Feature.MissingStepError
+  defp strip_spaces_from_blank_lines(str) when is_binary(str) do
+    String.replace(str, ~r/\n\s+\n/, "\n\n")
+  end
+
+  defp output_contains?(output, message) do
+    strip_spaces_from_blank_lines(output) =~ strip_spaces_from_blank_lines(message)
+  end
 
   describe "provide simple missing steps" do
     test "Show missing Given step" do
       message = """
-      Please add a matching step for:
-      "Given I provide Given"
+           ** (Cabbage.Feature.MissingStepError) Please add a matching step for:
+           "Given I provide Given"
 
-        defgiven ~r/^I provide Given$/, _vars, state do
-          # Your implementation here
-        end
+             defgiven ~r/^I provide Given$/, _vars, state do
+               # Your implementation here
+             end
       """
 
-      assert_raise MissingStepError, message, fn ->
         defmodule FeatureSuggestionTest do
           use Cabbage.Feature, file: "simple.feature"
         end
-      end
+
+      {_result, output} = CabbageTestHelper.run()
+      assert output_contains?(output, message)
     end
 
     test "Show missing And step" do
       message = """
-      Please add a matching step for:
-      "Given I provide And"
+           ** (Cabbage.Feature.MissingStepError) Please add a matching step for:
+           "Given I provide And"
 
-        defgiven ~r/^I provide And$/, _vars, state do
-          # Your implementation here
-        end
+             defgiven ~r/^I provide And$/, _vars, state do
+               # Your implementation here
+             end
       """
 
-      assert_raise MissingStepError, message, fn ->
-        defmodule FeatureSuggestionTest2 do
-          use Cabbage.Feature, file: "simple.feature"
+      defmodule FeatureSuggestionTest2 do
+        use Cabbage.Feature, file: "simple.feature"
 
-          defgiven ~r/^I provide Given$/, _vars, _state do
-            # Your implementation here
-          end
+        defgiven ~r/^I provide Given$/, _vars, _state do
+          # Your implementation here
         end
       end
+
+      {_result, output} = CabbageTestHelper.run()
+      assert output_contains?(output, message)
     end
 
     test "Show missing When step" do
       message = """
-      Please add a matching step for:
-      "When I provide When"
+           ** (Cabbage.Feature.MissingStepError) Please add a matching step for:
+           "When I provide When"
 
-        defwhen ~r/^I provide When$/, _vars, state do
-          # Your implementation here
-        end
+             defwhen ~r/^I provide When$/, _vars, state do
+               # Your implementation here
+             end
       """
 
-      assert_raise MissingStepError, message, fn ->
-        defmodule FeatureSuggestionTest3 do
-          use Cabbage.Feature, file: "simple.feature"
+      defmodule FeatureSuggestionTest3 do
+        use Cabbage.Feature, file: "simple.feature"
 
-          defgiven ~r/^I provide Given$/, _vars, _state do
+        defgiven ~r/^I provide Given$/, _vars, _state do
             # Your implementation here
-          end
+        end
 
-          defgiven ~r/^I provide And$/, _vars, _state do
+        defgiven ~r/^I provide And$/, _vars, _state do
             # Your implementation here
-          end
         end
       end
+
+      {_result, output} = CabbageTestHelper.run()
+      assert output_contains?(output, message)
     end
 
     test "Show missing Then step" do
       message = """
-      Please add a matching step for:
-      "Then I provide Then"
+           ** (Cabbage.Feature.MissingStepError) Please add a matching step for:
+           "Then I provide Then"
 
-        defthen ~r/^I provide Then$/, _vars, state do
-          # Your implementation here
-        end
+             defthen ~r/^I provide Then$/, _vars, state do
+               # Your implementation here
+             end
       """
 
-      assert_raise MissingStepError, message, fn ->
-        defmodule FeatureSuggestionTest4 do
-          use Cabbage.Feature, file: "simple.feature"
+      defmodule FeatureSuggestionTest4 do
+        use Cabbage.Feature, file: "simple.feature"
 
-          defgiven ~r/^I provide Given$/, _vars, _state do
+        defgiven ~r/^I provide Given$/, _vars, _state do
             # Your implementation here
-          end
+        end
 
-          defgiven ~r/^I provide And$/, _vars, _state do
+        defgiven ~r/^I provide And$/, _vars, _state do
             # Your implementation here
-          end
+        end
 
-          defwhen ~r/^I provide When$/, _vars, _state do
+        defwhen ~r/^I provide When$/, _vars, _state do
             # Your implementation here
-          end
         end
       end
+
+      {_result, output} = CabbageTestHelper.run()
+      assert output_contains?(output, message)
     end
 
     test "Doesnt suggest any features" do
@@ -127,100 +137,104 @@ defmodule Cabbage.FeatureSuggestionTest do
   describe "provide dynamic missing steps" do
     test "Show missing dynamic Given step with one dynamic part" do
       message = """
-      Please add a matching step for:
-      "Given I provide Given with \'given dynamic\' part"
+           ** (Cabbage.Feature.MissingStepError) Please add a matching step for:
+           "Given I provide Given with \'given dynamic\' part"
 
-        defgiven ~r/^I provide Given with \'(?<string_1>[^\']+)\' part$/, %{string_1: string_1}, state do
-          # Your implementation here
-        end
+             defgiven ~r/^I provide Given with \'(?<string_1>[^\']+)\' part$/, %{string_1: string_1}, state do
+               # Your implementation here
+             end
       """
 
-      assert_raise MissingStepError, message, fn ->
-        defmodule FeatureSuggestionTest6 do
-          use Cabbage.Feature, file: "dynamic.feature"
-        end
+      defmodule FeatureSuggestionTest6 do
+        use Cabbage.Feature, file: "dynamic.feature"
       end
+
+      {_result, output} = CabbageTestHelper.run()
+      assert output_contains?(output, message)
     end
 
     test "Show missing dynamic When step with two dynamic parts" do
       message = """
-      Please add a matching step for:
-      "When I provide When with \"when dynamic\" part and with one more \"another when dynamic\" part"
+           ** (Cabbage.Feature.MissingStepError) Please add a matching step for:
+           "When I provide When with \"when dynamic\" part and with one more \"another when dynamic\" part"
 
-        defwhen ~r/^I provide When with \"(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part$/, %{string_1: string_1, string_2: string_2}, state do
-          # Your implementation here
-        end
+             defwhen ~r/^I provide When with \"(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part$/, %{string_1: string_1, string_2: string_2}, state do
+               # Your implementation here
+             end
       """
 
-      assert_raise MissingStepError, message, fn ->
-        defmodule FeatureSuggestionTest7 do
-          use Cabbage.Feature, file: "dynamic.feature"
+      defmodule FeatureSuggestionTest7 do
+        use Cabbage.Feature, file: "dynamic.feature"
 
-          defgiven ~r/^I provide Given with \'(?<string_1>[^\']+)\' part$/, %{string_1: _string_1}, _state do
+        defgiven ~r/^I provide Given with \'(?<string_1>[^\']+)\' part$/, %{string_1: _string_1}, _state do
             # Your implementation here
-          end
         end
       end
+
+      {_result, output} = CabbageTestHelper.run()
+      assert output_contains?(output, message)
     end
 
     test "Show missing dynamic Then step with two dynamic parts one of which is docs" do
       message = """
-      Please add a matching step for:
-      "Then I provide Then with number 6 part and with docs part\"
+           ** (Cabbage.Feature.MissingStepError) Please add a matching step for:
+           "Then I provide Then with number 6 part and with docs part\"
 
-        defthen ~r/^I provide Then with number (?<number_1>\d+) part and with docs part$/, %{number_1: number_1, doc_string: doc_string}, state do
-          # Your implementation here
-        end
+             defthen ~r/^I provide Then with number (?<number_1>\d+) part and with docs part$/, %{number_1: number_1, doc_string: doc_string}, state do
+               # Your implementation here
+             end
       """
 
-      assert_raise MissingStepError, message, fn ->
-        defmodule FeatureSuggestionTest8 do
-          use Cabbage.Feature, file: "dynamic.feature"
+      defmodule FeatureSuggestionTest8 do
+        use Cabbage.Feature, file: "dynamic.feature"
 
-          defgiven ~r/^I provide Given with \'(?<string_1>[^\']+)\' part$/, %{string_1: string_1}, state do
+        defgiven ~r/^I provide Given with \'(?<string_1>[^\']+)\' part$/, %{string_1: _string_1}, _state do
             # Your implementation here
-          end
-
-          defwhen ~r/^I provide When with \"(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part$/,
-                  %{string_1: _string_1, string_2: _string_2},
-                  _state do
-            # Your implementation here
-          end
         end
-      end
+
+        defwhen ~r/^I provide When with \"(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part$/,
+             %{string_1: _string_1, string_2: _string_2},
+             _state do
+            # Your implementation here
+        end
+        end
+
+      {_result, output} = CabbageTestHelper.run()
+      assert output_contains?(output, message)
     end
 
     test "Show missing dynamic And step with three dynamic parts one of which is docs" do
       message = """
-      Please add a matching step for:
-      "Then I provide And with \"and dynamic\" part and with one more \"another and dynamic\" part and with table part"
+           ** (Cabbage.Feature.MissingStepError) Please add a matching step for:
+           "Then I provide And with \"and dynamic\" part and with one more \"another and dynamic\" part and with table part"
 
-        defthen ~r/^I provide And with "(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part and with table part$/, %{string_1: string_1, string_2: string_2, table: table}, state do
-          # Your implementation here
-        end
+             defthen ~r/^I provide And with "(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part and with table part$/, %{string_1: string_1, string_2: string_2, table: table}, state do
+               # Your implementation here
+             end
       """
 
-      assert_raise MissingStepError, message, fn ->
-        defmodule FeatureSuggestionTest9 do
-          use Cabbage.Feature, file: "dynamic.feature"
+      defmodule FeatureSuggestionTest9 do
+        use Cabbage.Feature, file: "dynamic.feature"
 
-          defgiven ~r/^I provide Given with \'(?<string_1>[^\']+)\' part$/, %{string_1: _string_1}, _state do
+        defgiven ~r/^I provide Given with \'(?<string_1>[^\']+)\' part$/, %{string_1: _string_1}, _state do
             # Your implementation here
-          end
+        end
 
-          defwhen ~r/^I provide When with \"(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part$/,
-                  %{string_1: _string_1, string_2: _string_2},
-                  _state do
+        defwhen ~r/^I provide When with \"(?<string_1>[^\"]+)\" part and with one more \"(?<string_2>[^\"]+)\" part$/,
+             %{string_1: _string_1, string_2: _string_2},
+             _state do
             # Your implementation here
-          end
+        end
 
-          defthen ~r/^I provide Then with number (?<number_1>\d+) part and with docs part$/,
-                  %{number_1: _number_1, doc_string: _doc_string},
-                  _state do
-            # Your implementation here
-          end
+        defthen ~r/^I provide Then with number (?<number_1>\d+) part and with docs part$/,
+            %{number_1: _number_1, doc_string: _doc_string},
+            _state do
+          # Your implementation here
         end
       end
+
+      {_result, output} = CabbageTestHelper.run()
+      assert output_contains?(output, message)
     end
 
     test "Do not show suggested items if all present" do
@@ -261,19 +275,20 @@ defmodule Cabbage.FeatureSuggestionTest do
     """
     test "Show missing dynamic Given step" do
       message = """
-      Please add a matching step for:
-      "Given there is given a value"
+           ** (Cabbage.Feature.MissingStepError) Please add a matching step for:
+           "Given there is given a value"
 
-        defgiven ~r/^there is given a value$/, _vars, state do
-          # Your implementation here
-        end
+             defgiven ~r/^there is given a value$/, _vars, state do
+               # Your implementation here
+             end
       """
 
-      assert_raise MissingStepError, message, fn ->
-        defmodule FeatureSuggestionTest11 do
-          use Cabbage.Feature, file: "outline.feature"
-        end
+      defmodule FeatureSuggestionTest11 do
+        use Cabbage.Feature, file: "outline.feature"
       end
+
+      {_result, output} = CabbageTestHelper.run()
+      assert output_contains?(output, message)
     end
   end
 end


### PR DESCRIPTION
They were previously compile-time errors which would prevent any
*working* tests from actually running. This change allows you to write
out your full Gherkin .feature file and run your tests without having to
comment out the unimplemented steps in the .feature file.