### PR TITLE
Fix warnings on elixir 1.10

### DIFF
--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -344,7 +344,7 @@ defmodule Cabbage.Feature do
   """
   defmacro import_steps(module) do
     quote do
-      if Code.ensure_compiled?(unquote(module)) do
+      if Code.ensure_compiled(unquote(module)) do
         for step <- unquote(module).raw_steps() do
           Module.put_attribute(__MODULE__, :steps, step)
         end
@@ -357,7 +357,7 @@ defmodule Cabbage.Feature do
   """
   defmacro import_tags(module) do
     quote do
-      if Code.ensure_compiled?(unquote(module)) do
+      if Code.ensure_compiled(unquote(module)) do
         for {name, block} <- unquote(module).raw_tags() do
           Cabbage.Feature.Helpers.add_tag(__MODULE__, name, block)
         end


### PR DESCRIPTION
`Code.ensure_compiled?` is deprecated on elixir 1.10. You can see it mentioned in the [release notes](https://github.com/elixir-lang/elixir/releases/tag/v1.10.0).