### PR TITLE
Remove duplication in test function name

### DIFF
--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -230,13 +230,7 @@ defmodule Cabbage.Feature do
 
           tags = Cabbage.Feature.Helpers.map_tags(scenario.tags) || []
 
-          name =
-            ExUnit.Case.register_test(
-              __ENV__,
-              :scenario,
-              scenario.name,
-              tags
-            )
+          name = ExUnit.Case.register_test(__ENV__, :scenario, "test", tags)
 
           def unquote(name)(exunit_state) do
             Cabbage.Feature.Helpers.start_state(unquote(scenario.name), __MODULE__, exunit_state)


### PR DESCRIPTION
`ExUnit.Case.register_test/4` joins the test name with the name of the describe block to build a unique name and returns it as an atom. Since we use `scenario.name` already in the describe block, and we create only one test, we can give it a generic name.

This reduces the likelyhood to reach the [erlang system limit] of 255 characters in an atom.

[erlang system limit]: https://erlang.org/documentation/doc-5.8.4/doc/efficiency_guide/advanced.html#:~:text=Characters%20in%20an%20atom