### PR TITLE
refactor: Register test scenarios with ExUnit.Case.register_test/6

### DIFF
--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -232,7 +232,9 @@ defmodule Cabbage.Feature do
 
           name =
             ExUnit.Case.register_test(
-              __ENV__,
+              __MODULE__,
+              __ENV__.file,
+              __ENV__.line,
               :scenario,
               scenario.name,
               tags


### PR DESCRIPTION
warning: ExUnit.Case.register_test/4 is deprecated. Use register_test/6 instead
