### PR TITLE
Use ExUnit.Case.register_test/6 instead of ExUnit.Case.register_test/…

### DIFF
--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -230,13 +230,9 @@ defmodule Cabbage.Feature do
 
           tags = Cabbage.Feature.Helpers.map_tags(scenario.tags) || []
 
+          %{module: mod, file: file, line: line} = __ENV__
           name =
-            ExUnit.Case.register_test(
-              __ENV__,
-              :scenario,
-              scenario.name,
-              tags
-            )
+            ExUnit.Case.register_test(mod, file, line, :scenario, scenario.name, tags)
 
           def unquote(name)(exunit_state) do
             Cabbage.Feature.Helpers.start_state(unquote(scenario.name), __MODULE__, exunit_state)


### PR DESCRIPTION
Use `ExUnit.Case.register_test/6` instead of `ExUnit.Case.register_test/4` which is deprecated.

Thanks to @dmitry-semenov for https://github.com/cabbage-ex/cabbage/pull/90 which first included this fix.

@arfl -- is this good to merge?
